### PR TITLE
Fixes for Pad and some reshaping

### DIFF
--- a/onnx_coreml/_backend_rep.py
+++ b/onnx_coreml/_backend_rep.py
@@ -21,15 +21,22 @@ class CoreMLRep(BackendRep):
     def run(self, inputs, **kwargs):
         super(CoreMLRep, self).run(inputs, **kwargs)
         inputs_ = inputs
+        _reshaped = False
         for i, input_ in enumerate(inputs_):
             shape = input_.shape
             if len(shape) == 4:
                 # reshape to [seq, batch, channels, height, width]
                 inputs_[i] = input_[np.newaxis, :]
+                _reshaped = True
         input_dict = dict(
             zip(self.input_names,
                 map(np.array, inputs_)))
         prediction = self.model.predict(input_dict, self.useCPUOnly)
         output_values = [prediction[name] for name in self.output_names]
+        for i, output_ in enumerate(output_values):
+            shape = output_.shape
+            if _reshaped and len(shape) == 5 and shape[1] == 1:
+                # get rid of batch dimension
+                output_values[i] = np.squeeze(output_, axis=1)
         return namedtupledict('Outputs',
                               self.output_names)(*output_values)

--- a/onnx_coreml/_operators.py
+++ b/onnx_coreml/_operators.py
@@ -366,21 +366,24 @@ def _convert_pad(builder, node):
     elif mode == 'edge':
         mode = 'replication'
     pads = node.attrs['pads']
-    if len(pads) > 4:
-        diff = len(pads) - 4
-        if pads[:diff].count(0) != diff:
-            raise NotImplementedError(
-                "Paddings value {} not supported".format(pads,)
-            )
-        pads = pads[diff:]
-    pad_t = pads[0]
-    pad_b = pads[1]
-    pad_l = 0
-    pad_r = 0
-    if len(pads) > 2:
-        pad_l = pads[2]
-    if len(pads) > 3:
-        pad_r = pads[3]
+    assert len(pads) % 2 == 0 and len(pads) >= 2
+    start = pads[:len(pads)//2]
+    end = pads[len(pads)//2:]
+    if len(start) < 2:
+        start.append(0)
+        end.append(0)
+
+    def _all_zero(x):
+        return x.count(0) == len(x)
+
+    if not _all_zero(start[:-2]) and not _all_zero(end[:-2]):
+        raise NotImplementedError(
+	    "Paddings value {} not supported".format(pads,)
+        )
+    pad_t = start[-2]
+    pad_b = end[-2]
+    pad_l = start[-1]
+    pad_r = end[-1]
     value = node.attrs.get('value', 0.0)
     builder.add_padding(
         name=node.name,

--- a/tests/onnx_backend_test.py
+++ b/tests/onnx_backend_test.py
@@ -66,7 +66,14 @@ backend_test.exclude('test_matmul')
 backend_test.exclude('test_slice')
 backend_test.exclude('test_default_axes')
 backend_test.exclude('test_add_bcast')
-
+# big models tests
+# backend_test.exclude('test_bvlc_alexnet')
+# backend_test.exclude('test_resnet50')
+# backend_test.exclude('test_vgg16')
+# backend_test.exclude('test_vgg19')
+# backend_test.exclude('test_densenet121')
+# backend_test.exclude('test_inception_v1')
+# backend_test.exclude('test_inception_v2')
 
 globals().update(backend_test
                  .enable_report()


### PR DESCRIPTION
1. Pad op changed it's format upstream
2. Does a bit more reshapes to make some of the newly added tests pass. Most of them have non-1 batch dimension and NCHW format - thus discarding the batch dimension when invoking CoreML works fine.

With these changes number of failing tests is down from 64 to 44.

There are still a lot of newly failing tests, some of them are missing mappings, some of them might not be properly supported by CoreML in general (like arbitrary dim tensors).