### PR TITLE
Submodule c2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ example/fast-neural-style/fast-neural-style/
 
 # CoreML models
 *.mlmodel
+
+virtualenv
+.pytest_cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/onnx"]
 	path = third_party/onnx
 	url = https://github.com/onnx/onnx.git
+[submodule "third_party/caffe2"]
+	path = third_party/caffe2
+	url = git@github.com:caffe2/caffe2.git

--- a/install-develop.sh
+++ b/install-develop.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -ex
+
+# realpath might not be available on MacOS
+script_path=$(python -c "import os; import sys; print(os.path.realpath(sys.argv[1]))" "${BASH_SOURCE[0]}")
+top_dir=$(dirname "$script_path")
+REPOS_DIR="$top_dir/third_party"
+BUILD_DIR="$top_dir/build"
+
+_check_submodule_present() {
+    if [ ! -f "$REPOS_DIR/$@/setup.py" ]; then
+       echo Didn\'t find $@ submodule. Please run: git submodule update --recursive --init
+        exit 1
+    fi
+}
+
+_check_submodule_present caffe2
+_check_submodule_present onnx
+
+if ! echo "$PATH" | grep ccache; then
+    echo Warning: CCache is not in the path. Incremental builds will be slow.
+    read -p "Press enter to continue"
+fi
+
+
+mkdir -p "$BUILD_DIR"
+
+_pip_install() {
+    if [[ -n "$CI" ]]; then
+        ccache -z
+    fi
+    if [[ -n "$CI" ]]; then
+        time pip install "$@"
+    else
+        pip install "$@"
+    fi
+    if [[ -n "$CI" ]]; then
+        ccache -s
+    fi
+}
+
+# Install caffe2
+_pip_install -b "$BUILD_DIR/caffe2" "file://$REPOS_DIR/caffe2#egg=caffe2"
+
+# Install onnx
+_pip_install -e "$REPOS_DIR/onnx"
+
+# Install onnx-coreml
+_pip_install -e .

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -ex
+
+# realpath might not be available on MacOS
+script_path=$(python -c "import os; import sys; print(os.path.realpath(sys.argv[1]))" "${BASH_SOURCE[0]}")
+top_dir=$(dirname "$script_path")
+REPOS_DIR="$top_dir/third_party"
+BUILD_DIR="$top_dir/build"
+
+_check_submodule_present() {
+    if [ ! -f "$REPOS_DIR/$@/setup.py" ]; then
+       echo Didn\'t find $@ submodule. Please run: git submodule update --recursive --init
+        exit 1
+    fi
+}
+
+_check_submodule_present caffe2
+_check_submodule_present onnx
+
+if ! echo "$PATH" | grep ccache; then
+    echo Warning: CCache is not in the path. Incremental builds will be slow.
+fi
+
+
+mkdir -p "$BUILD_DIR"
+
+_pip_install() {
+    if [[ -n "$CI" ]]; then
+        ccache -z
+    fi
+    if [[ -n "$CI" ]]; then
+        time pip install "$@"
+    else
+        pip install "$@"
+    fi
+    if [[ -n "$CI" ]]; then
+        ccache -s
+    fi
+}
+
+# Install caffe2
+_pip_install -b "$BUILD_DIR/caffe2" "file://$REPOS_DIR/caffe2#egg=caffe2"
+python -c 'from caffe2.python import build; from pprint import pprint; pprint(build.build_options)'
+
+# Install onnx
+_pip_install -b "$BUILD_DIR/onnx" "file://$REPOS_DIR/onnx#egg=onnx"
+
+# Install onnx-coreml
+_pip_install .

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'click',
         'numpy',
         'coremltools>=0.6.3',
-        'onnx>=0.2.1'
     ],
     setup_requires=['pytest-runner'],
     tests_require=[

--- a/tests/_test_utils.py
+++ b/tests/_test_utils.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import numpy as np
 import numpy.testing as npt
 from onnx import helper, TensorProto
-import onnx_caffe2.backend
+import caffe2.python.onnx.backend
 
 from onnx_coreml import convert
 
@@ -68,7 +68,7 @@ def _shape_from_onnx_value_info(v):
 
 
 def _forward_onnx_model(model, input_dict):
-    prepared_backend = onnx_caffe2.backend.prepare(model)
+    prepared_backend = caffe2.python.onnx.backend.prepare(model)
     out = prepared_backend.run(input_dict)
     result = [out[v.name] for v in model.graph.output]
     output_shapes = [

--- a/tests/onnx_backend_test.py
+++ b/tests/onnx_backend_test.py
@@ -8,19 +8,19 @@ import unittest
 import onnx
 
 import onnx.backend.test
-import onnx_caffe2.backend
+import caffe2.python.onnx.backend
 
 from onnx_coreml._backend import CoreMLBackend
 
 
-# TODO: don't use onnx_caffe2 to infer output shapes
+# TODO: don't use caffe2 to infer output shapes
 class CoreMLTestingBackend(CoreMLBackend):
     @classmethod
     def run_node(cls, node, inputs, device='CPU'):
         '''
         CoreML requires full model for prediction, not just single layer.
         Also input/output shapes are required to build CoreML spec for model.
-        As a temporary decision we use onnx_caffe2 backend for shape inference
+        As a temporary decision we use caffe2 backend for shape inference
         task to build the appropriate ONNX model and convert it to
         CoreML model.
         '''
@@ -36,7 +36,7 @@ class CoreMLTestingBackend(CoreMLBackend):
             )
             graph_inputs.append(value_info)
 
-        c2_result = onnx_caffe2.backend.run_node(node, inputs, device)
+        c2_result = caffe2.python.onnx.backend.run_node(node, inputs, device)
 
         graph_outputs = []
         for i in range(len(node.output)):


### PR DESCRIPTION
(see stacked commits inside this pull request)

- Add caffe2 submodule. This dependency should be removed eventually, but is currently needed
- Remove external onnx dependency since it's now a submodule
- Fix onnx_caffe2 imports to caffe2.python.onnx
- Add some useful .gitignore entries
- Add install.sh and install-develop.sh