### PR TITLE
Remove pytorch submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "third_party/onnx"]
 	path = third_party/onnx
 	url = https://github.com/onnx/onnx.git
-[submodule "third_party/pytorch"]
-	path = third_party/pytorch
-	url = https://github.com/pytorch/pytorch.git

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd onnx-coreml
 
 * click
 * numpy
-* coremltools (0.6.3+)
+* coremltools (0.8+)
 * onnx (0.2.1+)
 
 ## How to use

--- a/install-develop.sh
+++ b/install-develop.sh
@@ -15,7 +15,6 @@ _check_submodule_present() {
     fi
 }
 
-_check_submodule_present pytorch
 _check_submodule_present onnx
 
 _check_compilers_use_ccache() {
@@ -49,13 +48,6 @@ _pip_install() {
         ccache -s
     fi
 }
-
-# Install caffe2
-cd $REPOS_DIR/pytorch
-pip install -r caffe2/requirements.txt
-python setup_caffe2.py develop
-cd ../..
-python -c 'from caffe2.python import build; from pprint import pprint; pprint(build.build_options)'
 
 # Install onnx
 _pip_install -e "$REPOS_DIR/onnx"

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,6 @@ _check_submodule_present() {
     fi
 }
 
-_check_submodule_present pytorch
 _check_submodule_present onnx
 
 _check_compilers_use_ccache() {
@@ -48,13 +47,6 @@ _pip_install() {
         ccache -s
     fi
 }
-
-# Install caffe2
-cd $REPOS_DIR/pytorch
-pip install -r caffe2/requirements.txt
-python setup_caffe2.py develop
-cd ../..
-python -c 'from caffe2.python import build; from pprint import pprint; pprint(build.build_options)'
 
 # Install onnx
 _pip_install -b "$BUILD_DIR/onnx" "file://$REPOS_DIR/onnx#egg=onnx"

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ testpaths = tests
 
 [mypy]
 follow-imports = silent  # TODO Remove this
-# TODO Remove pytorch in future: mypy_path = stubs:third_party/pytorch:third_party/onnx
 mypy_path = stubs:third_party/onnx
 strict_optional = True
 warn_return_any = True

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         'click',
         'numpy',
-        'coremltools>=0.6.3',
+        'coremltools>=0.8',
         'onnx>=0.2.1',
         'typing>=3.6.4',
         'typing-extensions>=3.6.2.1',

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,10 @@ setup(
     install_requires=[
         'click',
         'numpy',
-        'coremltools>=0.8',
         'onnx>=0.2.1',
         'typing>=3.6.4',
         'typing-extensions>=3.6.2.1',
+        'coremltools>=0.8',
     ],
     setup_requires=['pytest-runner'],
     tests_require=[


### PR DESCRIPTION
The converter and the tests do not depend on caffe2 anymore so pytorch submodule is not required