### PR TITLE
Added translation function for the pow op

### DIFF
--- a/onnx_coreml/_operators.py
+++ b/onnx_coreml/_operators.py
@@ -1364,6 +1364,27 @@ def _convert_exp(builder, node, graph, err):  # type: (NeuralNetworkBuilder, Nod
     )
     _update_shape_mapping_unchanged(node, graph, err)
 
+def _convert_pow(builder, node, graph, err):  # type: (NeuralNetworkBuilder, Node, Graph, ErrorHandling) -> None
+
+    input2 = node.inputs[1]
+    is_supported = False
+    if input2 in node.input_tensors:
+        alpha = node.input_tensors[input2]
+        if len(alpha.shape) == 0:
+            is_supported = True
+
+    if not is_supported:
+        err.missing_initializer(node, "Only mode supported is when the second input is a scalar constant")
+
+    builder.add_unary(
+        name=node.name,
+        input_name=node.inputs[0],
+        output_name=node.outputs[0],
+        mode='power',
+        alpha = alpha
+    )
+    _update_shape_mapping_unchanged(node, graph, err)
+
 def _convert_flatten(builder, node, graph, err):  # type: (NeuralNetworkBuilder, Node, Graph, ErrorHandling) -> None
 
     def _add_flatten(input_names, output_names, **kwargs):
@@ -1746,6 +1767,7 @@ _ONNX_NODE_REGISTRY = {
     "Mul": _convert_mul,
     "Neg": _convert_neg,
     "Pad": _convert_pad,
+    "Pow": _convert_pow,
     "PRelu": _convert_prelu,
     "Reciprocal": _convert_reciprocal,
     "ReduceL1": _convert_reduce,

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -175,10 +175,22 @@ class OnnxModelTest(unittest.TestCase):
         torch_model.train(False)
         _test_torch_model_single_io(torch_model, (1, 1, 3, 3), (1, 3, 3))  # type: ignore
 
+    def test_pow(self): # type: () -> None
+        class Net(nn.Module):
+            def __init__(self):
+                super(Net, self).__init__()
+
+            def forward(self, x):
+                y = x.pow(3)
+                return y
+
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (3, 2, 3), (3, 2, 3))  # type: ignore
 
 
 if __name__ == '__main__':
     unittest.main()
     #suite = unittest.TestSuite()
-    #suite.addTest(OnnxModelTest("test_conv2D_transpose_2"))
+    #suite.addTest(OnnxModelTest("test_pow"))
     #unittest.TextTestRunner().run(suite)

--- a/tests/onnx_backend_node_test.py
+++ b/tests/onnx_backend_node_test.py
@@ -177,8 +177,6 @@ backend_test.exclude('test_dropout_default_cpu')
 backend_test.exclude('test_dropout_random_cpu')
 backend_test.exclude('test_gru_seq_length_cpu')
 backend_test.exclude('test_identity_cpu')
-backend_test.exclude('test_pow_bcast_scalar_cpu')
-backend_test.exclude('test_pow_bcast_array_cpu')
 backend_test.exclude('test_asin_example_cpu')
 backend_test.exclude('test_reduce_log_sum_exp_default_axes_keepdims_example_cpu')
 backend_test.exclude('test_reduce_log_sum_exp_default_axes_keepdims_random_cpu')
@@ -196,9 +194,6 @@ backend_test.exclude('test_expand_shape_model3_cpu')
 backend_test.exclude('test_expand_shape_model4_cpu')
 backend_test.exclude('test_expand_dim_changed_cpu')
 backend_test.exclude('test_expand_dim_unchanged_cpu')
-backend_test.exclude('test_pow_cpu')
-backend_test.exclude('test_pow_example_cpu')
-backend_test.exclude('test_operator_pow_cpu')
 backend_test.exclude('test_operator_chunk_cpu') # unequal splits
 backend_test.exclude('test_operator_permute2_cpu') # rank 6 input
 backend_test.exclude('test_maxpool_with_argmax_2d_precomputed_pads_cpu')
@@ -207,6 +202,11 @@ backend_test.exclude('test_gather_1_cpu')
 backend_test.exclude('test_gather_0_cpu')
 backend_test.exclude('test_Embedding_cpu') # gather op
 backend_test.exclude('test_Embedding_sparse_cpu') # gather op
+backend_test.exclude('test_pow_bcast_scalar_cpu')
+backend_test.exclude('test_pow_bcast_array_cpu')
+backend_test.exclude('test_pow_cpu')
+backend_test.exclude('test_pow_example_cpu')
+backend_test.exclude('test_operator_pow_cpu')
 
 # recurrent tests.
 backend_test.exclude('test_operator_rnn_cpu')


### PR DESCRIPTION
The case supported by CoreML is `x^alpha`, where alpha is a scalar constant 