### PR TITLE
Fix UnicodeDecodeError without pypandoc in Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
 except(IOError, ImportError):
-    long_description = open('README.md').read()
+    with open('README.md', "rb") as f:
+        long_description = f.read().decode("UTF-8")
 
 
 if sys.version_info[0] == 2:


### PR DESCRIPTION
Installing this package in Python3 without pypandoc results in the following exception:
``` UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 7339: ordinal not in range(128)```

This PR fixes that, tested with both Python 2 and 3