### PR TITLE
Fix linear mode for Upsample 

### DIFF
--- a/onnx_coreml/_operators.py
+++ b/onnx_coreml/_operators.py
@@ -1514,7 +1514,7 @@ def _convert_upsample(builder, node, graph, err):  # type: (NeuralNetworkBuilder
         width_scale = int(node.attrs.get('width_scale', 1))
     mode_convert = {
         "nearest": "NN",
-        "bilinear": "BILINEAR",
+        "linear": "BILINEAR",
     }
     mode = mode_convert[node.attrs["mode"].decode("UTF-8")]
     builder.add_upsample(


### PR DESCRIPTION
According to the specification `mode` can either be `nearest` or `linear`:
https://github.com/onnx/onnx/blob/rel-1.3.0/docs/Operators.md#attributes-58