### PR TITLE
Fix conv after reshape

### DIFF
--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -247,6 +247,26 @@ class OnnxModelTest(unittest.TestCase):
         torch_model.train(False)
         _test_torch_model_single_io(torch_model, (1, Cin, Win), (Cin, 1, Win))  # type: ignore
 
+    def test_conv_after_reshape(self):  # type: () -> None
+        class Net(nn.Module):
+            def __init__(self):
+                super(Net, self).__init__()
+                self.conv = torch.nn.Conv1d(in_channels=300,
+                                            out_channels=32,
+                                            kernel_size=3,
+                                            stride=1,
+                                            padding=0,
+                                            bias=True)
+
+            def forward(self, x):
+                x = x.view(1, 300, 100)
+                x = self.conv(x)
+                return x
+
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (1, 3, 100, 100), (3, 100, 100))  # type: ignore
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixed axis alignment error when convert conv ops after reshape. Also ignored useless params of ONNX conv op(W and B)