### PR TITLE
Fix scales for Upsample

### DIFF
--- a/onnx_coreml/_operators.py
+++ b/onnx_coreml/_operators.py
@@ -1522,8 +1522,10 @@ def _convert_upsample(builder, node, graph, err):  # type: (NeuralNetworkBuilder
         height_scale = int(scales[2])
         width_scale = int(scales[3])
     else:
-        height_scale = int(node.attrs.get('height_scale', 1))
-        width_scale = int(node.attrs.get('width_scale', 1))
+        key = next(iter(node.input_tensors.keys()))
+        scales = node.input_tensors[key]
+        height_scale = int(scales[2])
+        width_scale = int(scales[3])
     mode_convert = {
         "nearest": "NN",
         "linear": "BILINEAR",

--- a/onnx_coreml/_operators.py
+++ b/onnx_coreml/_operators.py
@@ -1521,11 +1521,14 @@ def _convert_upsample(builder, node, graph, err):  # type: (NeuralNetworkBuilder
             err.unsupported_op_configuration(builder, node, graph, "Unsupported scales {} for upsample".format(scales))
         height_scale = int(scales[2])
         width_scale = int(scales[3])
-    else:
+    elif len(node.input_tensors):
         key = next(iter(node.input_tensors.keys()))
         scales = node.input_tensors[key]
         height_scale = int(scales[2])
         width_scale = int(scales[3])
+    else:
+        height_scale = int(node.attrs.get('height_scale', 1))
+        width_scale = int(node.attrs.get('width_scale', 1))
     mode_convert = {
         "nearest": "NN",
         "linear": "BILINEAR",


### PR DESCRIPTION
Get `height_scale` and `width_scale` in case of `node.attrs` doesn't have `'scales'`