### PR TITLE
Simplfy convert flip

### DIFF
--- a/onnx_coreml/_operators.py
+++ b/onnx_coreml/_operators.py
@@ -1615,24 +1615,33 @@ def _convert_upsample(builder, node, graph, err):  # type: (NeuralNetworkBuilder
     _update_shape_mapping_unchanged(node, graph, err)
 
 def _convert_clip(builder, node, graph, err): # type: (NeuralNetworkBuilder, Node, Graph, ErrorHandling) -> None
-    max_limit = node.attrs.get('max',float(2^16-1))
-    min_limit = node.attrs.get('min',float(-(2^16-1)))
-    delta = max_limit - min_limit
-    builder.add_activation(name = node.name + '_scale_0_1', # type: ignore
-                           non_linearity = 'LINEAR',
-                           input_name = node.inputs[0],
-                           output_name = node.inputs[0] + '_scale_0_1',
-                           params = [1.0/delta, -min_limit/delta])
-    builder.add_activation(name = node.name + '_clip_0_1', # type: ignore
-                           non_linearity = 'SIGMOID_HARD',
-                           input_name = node.inputs[0] + '_scale_0_1',
-                           output_name = node.inputs[0] + '_clip_0_1',
-                           params = [1.0, 0.0])
-    builder.add_activation(name = node.name,
-                           non_linearity = 'LINEAR',
-                           input_name = node.inputs[0] + '_clip_0_1',
-                           output_name = node.outputs[0],
-                           params = [delta, min_limit])
+    min_limit = node.attrs.get('min', float(-2**16-1))
+    if node.attrs.get('max') is None:
+        builder.add_unary(name=node.name,
+                          input_name=node.inputs[0],
+                          output_name=node.outputs[0],
+                          mode='threshold',
+                          alpha=min_limit,
+                          shift=0,
+                          scale=1.0)
+    else:
+        max_limit = node.attrs.get('max')
+        delta = max_limit - min_limit
+        builder.add_activation(name = node.name + '_scale_0_1', # type: ignore
+                               non_linearity = 'LINEAR',
+                               input_name = node.inputs[0],
+                               output_name = node.inputs[0] + '_scale_0_1',
+                               params = [1.0/delta, -min_limit/delta])
+        builder.add_activation(name = node.name + '_clip_0_1', # type: ignore
+                               non_linearity = 'SIGMOID_HARD',
+                               input_name = node.inputs[0] + '_scale_0_1',
+                               output_name = node.inputs[0] + '_clip_0_1',
+                               params = [1.0, 0.0])
+        builder.add_activation(name = node.name,
+                               non_linearity = 'LINEAR',
+                               input_name = node.inputs[0] + '_clip_0_1',
+                               output_name = node.outputs[0],
+                               params = [delta, min_limit])
     _update_shape_mapping_unchanged(node, graph, err)
 
 def _convert_mvn(builder, node, graph, err): # type: (NeuralNetworkBuilder, Node, Graph, ErrorHandling) -> None


### PR DESCRIPTION
This pull request divides the clip node for 3 options:
1. Only lower bound clip - then we have a single coreml operator.
2. Only upper bound clip - then we have two coreml operators.
3. Both - then we have three coreml operators.
It also changes the latter case to simplier operators, without division.