### PR TITLE
Disabling travis test for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,7 @@ matrix:
   include:
     - os: linux
       sudo: required
-      env: PYTHON_VERSION=python2
-    - os: linux
-      sudo: required
       env: PYTHON_VERSION=python3
-    - os: osx
-      osx_image: xcode11
-      env: PYTHON_VERSION=python2
     - os: osx
       osx_image: xcode11
       env: PYTHON_VERSION=python3


### PR DESCRIPTION
Going forward, will be testing only on Python 3.x