### PR TITLE
Adding following ops support for ND tensor (CoreML 3)

### DIFF
--- a/tests/operators_test.py
+++ b/tests/operators_test.py
@@ -198,7 +198,7 @@ class SingleOperatorTest(unittest.TestCase):
                 momentum=momentum
             )
 
-    def test_gemm(self):  # type: () -> None
+    def test_gemm(self, disable_rank5_mapping=False):  # type: () -> None
         input_shape = (1, 2048)
         output_shape = (1, 5)
         W = from_array(
@@ -213,10 +213,16 @@ class SingleOperatorTest(unittest.TestCase):
             [output_shape],
             initializer=[W, b],
             decimal=3,
-            transB=1
+            transB=1,
+            disable_rank5_mapping=disable_rank5_mapping
         )
 
-    def test_gemm_transB_off(self):  # type: () -> None
+    @unittest.skipIf(macos_version() < MIN_MACOS_VERSION_10_15,
+                     'macOS 10.15+ required. Skipping test.')
+    def test_gemm_disable_rank5_mapping(self):
+        self.test_gemm(True)
+
+    def test_gemm_transB_off(self, disable_rank5_mapping=False):  # type: () -> None
         input_shape = (1, 2048)
         output_shape = (1, 5)
         W = from_array(
@@ -231,8 +237,14 @@ class SingleOperatorTest(unittest.TestCase):
             [output_shape],
             initializer=[W, b],
             decimal=3,
-            transB=0
+            transB=0,
+            disable_rank5_mapping=disable_rank5_mapping
         )
+    
+    @unittest.skipIf(macos_version() < MIN_MACOS_VERSION_10_15,
+                     'macOS 10.15+ required. Skipping test.')
+    def test_gemm_transB_off_disable_rank5_mapping(self):
+        self.test_gemm_transB_off(True)
 
     def test_lrn(self):  # type: () -> None
         _test_single_node(

--- a/tests/pytorch_model_test.py
+++ b/tests/pytorch_model_test.py
@@ -498,6 +498,153 @@ class ReshapeTransposeTests(unittest.TestCase):
         torch_model.train(False)
         _test_torch_model_single_io(torch_model, (1, 12, 4, 6), (12, 4, 6))  # type: ignore
 
+class UnaryOperationTests(unittest.TestCase):
+    '''
+    Unary Operation Test cases
+    '''
+    ## Sqrt tests
+    def sqrt_tensor(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return torch.sqrt(x)
+
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 4, 5), disable_rank5_mapping=disable_rank5_mapping)  # type: ignore
+
+class BinaryOperationTests(unittest.TestCase):
+    '''
+    Binary Operation Test cases
+    '''
+    ## Addition tests
+    def add_same_shape(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return torch.add(x, y)
+
+        y = torch.rand((18, 4, 5))
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 4, 5), disable_rank5_mapping=disable_rank5_mapping)  # type: ignore
+
+    def add_same_shape_multiple(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return x + y + y1 + y2 + y3
+
+        y = torch.rand((18, 4, 5))
+        y1 = torch.rand((4, 5))
+        y2 = torch.rand((18, 4, 5))
+        y3 = 7.234
+        
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 4, 5), disable_rank5_mapping=disable_rank5_mapping)  # type: ignore
+
+    def add_tensor_scalar(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return torch.add(x, y)
+
+        y = 5
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 4, 5), disable_rank5_mapping=disable_rank5_mapping)  # type: ignore
+
+    def add_diff_shape(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return torch.add(x, y)
+
+        y = torch.rand((4, 5))
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 4, 5), disable_rank5_mapping=disable_rank5_mapping)  # type: ignore
+
+    ## Subtraction tests
+    def sub_same_shape(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return torch.sub(x, y)
+
+        y = torch.rand((18, 4, 5))
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 4, 5), disable_rank5_mapping=disable_rank5_mapping)  # type: ignore
+
+    def sub_same_shape_multiple(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return x - y - y1 - y2 - y3
+
+        y = torch.rand((18, 4, 5))
+        y1 = torch.rand((4, 5))
+        y2 = torch.rand((18, 4, 5))
+        y3 = 7.234
+        
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 4, 5), disable_rank5_mapping=disable_rank5_mapping)  # type: ignore
+
+    def sub_tensor_scalar(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return torch.sub(x, y)
+
+        y = 5
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 4, 5), disable_rank5_mapping=disable_rank5_mapping)  # type: ignore
+
+    def sub_diff_shape(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return torch.sub(x, y)
+
+        y = torch.rand((4, 5))
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 4, 5), disable_rank5_mapping=disable_rank5_mapping)  # type: ignore
+
+    def bianry_ops_mix_test(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return ((x * g + a) - d * (c + b) + (a * e - g) / e) / f
+
+        a = torch.rand((18, 4, 5))
+        b = torch.rand((4, 5))
+        c = torch.rand((18, 4, 5))
+        d = 7.234
+        e = torch.rand((5))
+        f = 8.234
+        g = 5
+         
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 4, 5), disable_rank5_mapping=disable_rank5_mapping)  # type: ignore
+
+class ReduceOperationTests(unittest.TestCase):
+    '''
+    Reduction Operation Test cases
+    '''
+    ## Reduction tests
+    def reduce_sum(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return x.sum(dim=0)
+
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (4, 5), disable_rank5_mapping=disable_rank5_mapping)
+
+    def reduce_mean(self, disable_rank5_mapping=True):
+        class Net(nn.Module):
+            def forward(self, x):
+                return x.mean(dim=1) 
+
+        torch_model = Net()  # type: ignore
+        torch_model.train(False)
+        _test_torch_model_single_io(torch_model, (18, 4, 5), (18, 5), disable_rank5_mapping=disable_rank5_mapping)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
1. Div
2. Exp
3. Gemm
4. Mul
5. Pow
6. ReduceL1
7. ReduceL2
8. ReduceLogSum
9. ReduceLogSumExp
10. ReduceMax
11. ReduceMin
12. ReduceProd
13. ReduceSum
14. ReduceSumSquare
15. Sqrt
16. Sub
17. Tanh

Adding test case for Binary ops
Enabling test case for Gemm
TODO: Verification of Gemm when B and C are not constant