### PR TITLE
fix wrong detection of mode if constant is byte string, provide default empty list for pads

### DIFF
--- a/onnx_coreml/_operators_nd.py
+++ b/onnx_coreml/_operators_nd.py
@@ -1309,8 +1309,13 @@ def _convert_pad(builder, node, graph, err):
     '''
     mode = node.attrs.get('mode', 'constant')
 
+    try:
+        mode = mode.decode()
+    except (UnicodeDecodeError, AttributeError):
+        pass
+
     if mode == 'constant':    
-        pads = node.attrs.get('pads')
+        pads = node.attrs.get('pads', [])
         value = node.attrs.get('value', 0.0)
 
         builder.add_constant_pad(


### PR DESCRIPTION
When converting an ONNX model that was created with `tf.keras` to CoreML, the mode may be given as a byte string. Then, the byte string must be converted to a `str` so that the subsequent check succeeds. 

Also, if the list of pads is empty, `add_constant_pad` fails because it gets passed `pad_amounts = None` even though the function is perfectly fine with an empty list. Therefore `node.attrs.get('pads')` should be `node.attrs.get('pads', [])`. 