### PR TITLE
Possible fix for Issue 374

### DIFF
--- a/onnx_coreml/_operators.py
+++ b/onnx_coreml/_operators.py
@@ -271,7 +271,7 @@ def _convert_add(builder, node, graph, err):  # type: (NeuralNetworkBuilder, Nod
     - (S=-1,B=-1,1,1,W)
     - (S=-1,B=-1,1,H,1)
     - (S=-1,B=-1,C,1,W)
-    - (S=-1,B=-1,C,H,1)    
+    - (S=-1,B=-1,C,H,1)
     '''
     _convert_broadcast_op(builder, node, graph, err, "ADD")
 
@@ -398,7 +398,7 @@ def _add_conv(input_names, output_names, **kwargs):
 
     output_name = output_names[0]
     pre_padding_input_name = input_names[0]
-    
+
     if params_dict.get('is_post_crop', False):
         output_name += '_conv_tranpose_post_crop'
     if params_dict.get('is_pre_pad', False):
@@ -406,7 +406,7 @@ def _add_conv(input_names, output_names, **kwargs):
 
     if params_dict['W'] is None and len(node.inputs) == 1:
         return err.unsupported_op_configuration(builder, node, graph, "Kernel weight missing")
-    
+
     if params_dict['is_deconv']:
         oc = W_shape[1] * params_dict['groups']
         kc = W_shape[0]
@@ -712,7 +712,7 @@ def _convert_pool(builder, node, graph, err):  # type: (NeuralNetworkBuilder, No
 
     if 'ceil_mode' in node.attrs and node.attrs['ceil_mode'] == 1:
         return err.unsupported_op_configuration(builder, node, graph, "ceil_mod=1 not supported")
-    
+
     if 'dilations' in node.attrs:
         return err.unsupported_op_configuration(builder, node, graph, "dilations not supported")
 
@@ -1954,7 +1954,7 @@ _ONNX_NODE_REGISTRY = {
 
 _SEQUENCE_LAYERS_REGISTRY = set(["LSTM"])
 
-_CONST_INPUT_ALLOWED_LAYERS = set([ "Add", "Sum", "Mul", "Concat", "Max", "Min", "Div", "Reciprocal"])
+_CONST_INPUT_ALLOWED_LAYERS = set([ "Add", "Sub", "Sum", "Mul", "Concat", "Max", "Min", "Div", "Reciprocal"])
 
 def _get_node_converter_fn(builder, node, err):  # type: (NeuralNetworkBuilder, Node, ErrorHandling) -> Callable[[NeuralNetworkBuilder, Node, Graph, ErrorHandling], None]
     """


### PR DESCRIPTION
We have encountered the same issue as reported in #374. It is that converting a "Sub" node with a constant tensor fails when the target is iOS 12. The following is the traceback we got:

```
1/178: Converting Node Type Sub
Traceback (most recent call last):
  File "convert.py", line 13, in <module>
    model = convert("model.onnx", image_input_names=["Input_0"])
  File "/Users/takeshi_kanmae/Development/onnx-coreml/onnx_coreml/converter.py", line 629, in convert
    _convert_node(builder, node, graph, err)
  File "/Users/takeshi_kanmae/Development/onnx-coreml/onnx_coreml/_operators.py", line 1985, in _convert_node
    return converter_fn(builder, node, graph, err)
  File "/Users/takeshi_kanmae/Development/onnx-coreml/onnx_coreml/_operators.py", line 279, in _convert_sub
    _convert_broadcast_op(builder, node, graph, err, "ADD")
  File "/Users/takeshi_kanmae/Development/onnx-coreml/onnx_coreml/_operators.py", line 71, in _convert_broadcast_op
    ranks = [len(graph.onnx_coreml_shape_mapping[input_]) for input_ in node.inputs]
  File "/Users/takeshi_kanmae/Development/onnx-coreml/onnx_coreml/_operators.py", line 71, in <listcomp>
    ranks = [len(graph.onnx_coreml_shape_mapping[input_]) for input_ in node.inputs]
KeyError: 'v328'
```

I figured that this happens because a constant tensor shape is not properly registered to `Graph.onnx_coreml_shape_mapping` in `_add_const_inputs_if_required()` in `_operators` module. 

This Pull Request adds "Sub" to `_CONST_INPUT_ALLOWED_LAYERS` so that `_add_const_inputs_if_required()` properly register the constant tensor shape for "Sub" node.