### PR TITLE
Add --minimum_ios_deployment_target to convert-onnx-to-coreml ?

### DIFF
--- a/onnx_coreml/bin/convert.py
+++ b/onnx_coreml/bin/convert.py
@@ -19,10 +19,14 @@ from typing import Text, IO
 @click.option('-o', '--output', required=True,
               type=str,
               help='Output path for the CoreML *.mlmodel file')
-def onnx_to_coreml(onnx_model, output):  # type: (IO[str], str) -> None
+@click.option('-t', '--minimum_ios_deployment_target', required=False,
+              default='11.2',
+              type=str,
+              help='Output path for the CoreML *.mlmodel file')
+def onnx_to_coreml(onnx_model, output, **kargs):  # type: (IO[str], str) -> None
     onnx_model_proto = onnx_pb.ModelProto()
     onnx_model_proto.ParseFromString(onnx_model.read())
-    coreml_model = convert(onnx_model_proto)
+    coreml_model = convert(onnx_model_proto, **kargs)
     coreml_model.save(output)
 
 


### PR DESCRIPTION
Hello,

I don't know if you need such feature, but since it can be a useful change I share it with you.

The only options of `convert-onnx-to-coreml` is the output `-o`. If you want to convert a model requiring CoreML2 or CoreML3 features, you get a message which tell him to try with a higher coreml version number. Unfortunately I did not found any way to change this number without doing the export manually in python. What I did is duplicate the export script and add the parameter.

Because I think I may not be the only one who want to convert models to coreml, I share it here.