### PR TITLE
insert version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup, find_packages
 from os import path
 import sys
-from onnx_coreml import __version__
 
-VERSION = __version__
+
+VERSION = '1.2'
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
When i installed from source using install-develop.sh, i got this error below.
It reads version from onnx_coreml.__init__ and it also imports convert that needs coremltools.
So, it occurs error no module coremltools that should be installed automatically.
<img width="860" alt="스크린샷 2020-02-18 오후 9 10 03" src="https://user-images.githubusercontent.com/18042906/74734967-12f5f300-5293-11ea-904e-f9bc75faf6ef.png">

